### PR TITLE
Add Participation Command

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -43,6 +43,8 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Address: ")
                 .append(person.getAddress())
+                .append("; Participation: ")
+                .append(person.getParticipation())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
         return builder.toString();

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -24,6 +24,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Participation;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -99,9 +100,10 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        Participation updatedParticipation = personToEdit.getParticipation();
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedParticipation, updatedTags);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/PartCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PartCommand.java
@@ -1,0 +1,91 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Participation;
+import seedu.address.model.person.Person;
+
+/**
+ * Assigns a participation value to the person with the given index.
+ */
+public class PartCommand extends Command {
+
+    public static final String COMMAND_WORD = "part";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Assigns a participation value to the person identified by the index number used "
+            + "in the displayed person list.\n"
+            + "Parameters: INDEX PARTICIPATION\n"
+            + "Participation must be an integer from 0 to 5.\n"
+            + "Example: " + COMMAND_WORD + " 1 4";
+
+    public static final String MESSAGE_PARTICIPATION_SUCCESS =
+            "Updated participation for Person: %1$s";
+
+    private final Index targetIndex;
+    private final Participation participation;
+
+    /**
+     * @param index of the person in the filtered person list to edit
+     * @param participation participation value to assign to the person
+     */
+    public PartCommand(Index index, Participation participation) {
+        requireNonNull(index);
+        requireNonNull(participation);
+        this.targetIndex = index;
+        this.participation = participation;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToUpdate = lastShownList.get(targetIndex.getZeroBased());
+        Person updatedPerson = new Person(
+                personToUpdate.getName(),
+                personToUpdate.getPhone(),
+                personToUpdate.getEmail(),
+                personToUpdate.getAddress(),
+                participation,
+                personToUpdate.getTags());
+
+        model.setPerson(personToUpdate, updatedPerson);
+
+        return new CommandResult(String.format(MESSAGE_PARTICIPATION_SUCCESS, Messages.format(updatedPerson)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof PartCommand)) {
+            return false;
+        }
+
+        PartCommand otherPartCommand = (PartCommand) other;
+        return targetIndex.equals(otherPartCommand.targetIndex)
+                && participation.equals(otherPartCommand.participation);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("targetIndex", targetIndex)
+                .add("participation", participation)
+                .toString();
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Participation;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -45,7 +46,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, tagList);
+        Person person = new Person(name, phone, email, address, new Participation(0), tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.PartCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -70,6 +71,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+    case PartCommand.COMMAND_WORD:
+        return new PartCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/PartCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PartCommandParser.java
@@ -1,0 +1,41 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.PartCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Participation;
+
+/**
+ * Parses input arguments and creates a new PartCommand object.
+ */
+public class PartCommandParser implements Parser<PartCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the PartCommand
+     * and returns a PartCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PartCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        String[] parts = trimmedArgs.split("\\s+");
+
+        if (parts.length != 2) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PartCommand.MESSAGE_USAGE));
+        }
+
+        try {
+            Index index = ParserUtil.parseIndex(parts[0]);
+
+            if (!Participation.isValidParticipation(parts[1])) {
+                throw new ParseException(Participation.MESSAGE_CONSTRAINTS);
+            }
+
+            Participation participation = new Participation(parts[1]);
+            return new PartCommand(index, participation);
+        } catch (IllegalArgumentException | ParseException e) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PartCommand.MESSAGE_USAGE), e);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/person/Participation.java
+++ b/src/main/java/seedu/address/model/person/Participation.java
@@ -1,0 +1,83 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's participation level in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidParticipation(int)}
+ */
+public class Participation {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Participation must be an integer from 0 to 5.";
+    public final int value;
+
+    /**
+     * Constructs a {@code Participation}.
+     *
+     * @param participation A valid participation value.
+     */
+    public Participation(int participation) {
+        checkArgument(isValidParticipation(participation), MESSAGE_CONSTRAINTS);
+        value = participation;
+    }
+
+    /**
+     * Parses a string into a valid participation value.
+     */
+    public Participation(String participation) {
+        requireNonNull(participation);
+        try {
+            int parsedValue = Integer.parseInt(participation.trim());
+            checkArgument(isValidParticipation(parsedValue), MESSAGE_CONSTRAINTS);
+            value = parsedValue;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(MESSAGE_CONSTRAINTS);
+        }
+    }
+
+    /**
+     * Returns true if a given integer is within the valid range for participation.
+     */
+    public static boolean isValidParticipation(int test) {
+        return test >= 0 && test <= 5;
+    }
+
+    /**
+     * Returns true if a given string is a valid participation value.
+     */
+    public static boolean isValidParticipation(String test) {
+        requireNonNull(test);
+        try {
+            int parsedValue = Integer.parseInt(test.trim());
+            return isValidParticipation(parsedValue);
+        } catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof Participation)) {
+            return false;
+        }
+
+        Participation otherParticipation = (Participation) other;
+        return value == otherParticipation.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(value);
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -24,16 +24,18 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final Participation participation;
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Participation participation, Set<Tag> tags) {
         requireAllNonNull(name, phone, email, address, tags);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.participation = participation;
         this.tags.addAll(tags);
     }
 
@@ -51,6 +53,10 @@ public class Person {
 
     public Address getAddress() {
         return address;
+    }
+
+    public Participation getParticipation() {
+        return participation;
     }
 
     /**
@@ -94,13 +100,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
+                && participation.equals(otherPerson.participation)
                 && tags.equals(otherPerson.tags);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, participation, tags);
     }
 
     @Override
@@ -110,6 +117,7 @@ public class Person {
                 .add("phone", phone)
                 .add("email", email)
                 .add("address", address)
+                .add("participation", participation)
                 .add("tags", tags)
                 .toString();
     }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -13,6 +13,7 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Participation;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
@@ -28,6 +29,7 @@ class JsonAdaptedPerson {
     private final String phone;
     private final String email;
     private final String address;
+    private final Integer participation;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
 
     /**
@@ -36,11 +38,13 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+                             @JsonProperty("participation") Integer participation,
+                             @JsonProperty("tags") List<JsonAdaptedTag> tags) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.participation = participation;
         if (tags != null) {
             this.tags.addAll(tags);
         }
@@ -54,6 +58,7 @@ class JsonAdaptedPerson {
         phone = source.getPhone().value;
         email = source.getEmail().value;
         address = source.getAddress().value;
+        participation = source.getParticipation().value;
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
@@ -102,8 +107,17 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        final Participation modelParticipation;
+        if (participation == null) {
+            modelParticipation = new Participation(0);
+        } else if (!Participation.isValidParticipation(participation)) {
+            throw new IllegalValueException(Participation.MESSAGE_CONSTRAINTS);
+        } else {
+            modelParticipation = new Participation(participation);
+        }
+
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress,  modelParticipation, modelTags);
     }
 
 }


### PR DESCRIPTION
Current code has no participation command.

A participation command allows us to track the class participation for people in the contact list.

Let's add participation for the people in the contact list which is represented by numbers to indicate level of participation.

Participation for each person is 0 by default and can be changed to a value from 0-5.

Fixes #57 