### PR TITLE
Update Participation Command to Use Session

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -26,7 +26,7 @@ public class MarkCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Marks the person identified by the index number used in the displayed person list as PRESENT.\n"
-            + "Parameters: i/INDEX d/YYYY-MM-DD [g/CLASSSPACE]\n"
+            + "Parameters: i/INDEX d/YYYY-MM-DD [g/CLASS_SPACE]\n"
             + "Example: " + COMMAND_WORD + " i/1 d/2026-03-16 g/T02";
 
     public static final String MESSAGE_MARK_SUCCESS =
@@ -35,7 +35,7 @@ public class MarkCommand extends Command {
     public static final String MESSAGE_NO_ACTIVE_CLASS_SPACE =
             "No class space selected. Enter a class space first or provide g/CLASS_SPACE.";
 
-    public static final String MESSAGE_GROUP_NOT_FOUND =
+    public static final String MESSAGE_CLASS_SPACE_NOT_FOUND =
             "This class space does not exist.";
 
     private final Index targetIndex;
@@ -61,18 +61,18 @@ public class MarkCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        // Step 1: switch classspace if g/ provided
+        // Step 1: switch class space if g/ provided
         if (classSpaceName.isPresent()) {
             ClassSpaceName targetName = classSpaceName.get();
 
             if (model.findClassSpaceByName(targetName).isEmpty()) {
-                throw new CommandException(MESSAGE_GROUP_NOT_FOUND);
+                throw new CommandException(MESSAGE_CLASS_SPACE_NOT_FOUND);
             }
 
             model.switchToClassSpaceView(targetName);
         }
 
-        // Step 2: resolve active classspace
+        // Step 2: resolve active class space
         Optional<ClassSpaceName> activeClassSpace = model.getActiveClassSpaceName();
 
         if (activeClassSpace.isEmpty()) {

--- a/src/main/java/seedu/address/logic/commands/PartCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PartCommand.java
@@ -1,19 +1,25 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.classspace.ClassSpaceName;
 import seedu.address.model.person.Participation;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Session;
 
 /**
- * Assigns a participation value to a person identified using the displayed index.
+ * Assigns a participation value to a person identified using the displayed index
+ * for a specified session date in the current or specified class space.
  */
 public class PartCommand extends Command {
 
@@ -21,34 +27,69 @@ public class PartCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Assigns participation to the person identified by the index number in the displayed person list.\n"
-            + "Parameters: INDEX PARTICIPATION\n"
+            + "Parameters: i/INDEX d/YYYY-MM-DD [g/CLASSSPACE] pv/PARTICIPATION_VALUE\n"
             + "Participation must be an integer from 0 to 5.\n"
-            + "Example: " + COMMAND_WORD + " 1 4";
+            + "Example: " + COMMAND_WORD + " i/1 d/2026-03-16 g/T02 pv/4";
 
     public static final String MESSAGE_PARTICIPATION_SUCCESS =
             "Updated participation for Person: %1$s";
 
+    public static final String MESSAGE_CLASS_SPACE_NOT_FOUND =
+            "This class space does not exist.";
+
+    public static final String MESSAGE_NO_ACTIVE_CLASS_SPACE =
+            "No class space selected. Enter a class space first or provide g/CLASS_SPACE.";
+
     private final Index targetIndex;
+    private final LocalDate date;
+    private final Optional<ClassSpaceName> classSpaceName;
     private final Participation participation;
 
     /**
      * Creates a PartCommand to assign the specified {@code Participation}
-     * value to the person identified by the given {@code Index}.
+     * value to the person identified by the given {@code Index}, for the
+     * specified session date and current or specified class space.
      *
      * @param targetIndex Index of the person in the filtered person list whose participation
      *                    level is to be updated.
+     * @param date Date of the session to update participation for.
+     * @param classSpaceName Class space containing this session, if explicitly provided.
      * @param participation Participation value to assign to the specified person.
      */
-    public PartCommand(Index targetIndex, Participation participation) {
-        requireNonNull(targetIndex);
-        requireNonNull(participation);
+    public PartCommand(Index targetIndex, LocalDate date, Optional<ClassSpaceName> classSpaceName,
+                       Participation participation) {
+        requireAllNonNull(targetIndex, date, classSpaceName, participation);
         this.targetIndex = targetIndex;
+        this.date = date;
+        this.classSpaceName = classSpaceName;
         this.participation = participation;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        // Step 1: switch class space if g/ provided
+        if (classSpaceName.isPresent()) {
+            ClassSpaceName targetName = classSpaceName.get();
+
+            if (model.findClassSpaceByName(targetName).isEmpty()) {
+                throw new CommandException(MESSAGE_CLASS_SPACE_NOT_FOUND);
+            }
+
+            model.switchToClassSpaceView(targetName);
+        }
+
+        // Step 2: resolve active class space
+        Optional<ClassSpaceName> activeClassSpace = model.getActiveClassSpaceName();
+
+        if (activeClassSpace.isEmpty()) {
+            throw new CommandException(MESSAGE_NO_ACTIVE_CLASS_SPACE);
+        }
+
+        ClassSpaceName classSpace = activeClassSpace.get();
+
+        // Step 3: get person
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
@@ -56,10 +97,27 @@ public class PartCommand extends Command {
         }
 
         Person personToUpdate = lastShownList.get(targetIndex.getZeroBased());
-        Person updatedPerson = new Person(personToUpdate, participation);
 
+        // Step 4: get session
+        Session currentSession = personToUpdate.getOrCreateSession(classSpace, date);
+
+        // Step 5: update participation
+        Session updatedSession = new Session(
+                date,
+                currentSession.getAttendance(),
+                participation
+        );
+
+        // Step 6: update person
+        Person updatedPerson = personToUpdate.withUpdatedSession(classSpace, updatedSession);
+
+        // Step 7: update model
         model.setPerson(personToUpdate, updatedPerson);
-        return new CommandResult(String.format(MESSAGE_PARTICIPATION_SUCCESS, Messages.format(updatedPerson)));
+
+        return new CommandResult(String.format(
+                MESSAGE_PARTICIPATION_SUCCESS,
+                Messages.format(updatedPerson, classSpace, date))
+        );
     }
 
     @Override
@@ -68,12 +126,13 @@ public class PartCommand extends Command {
             return true;
         }
 
-        if (!(other instanceof PartCommand)) {
+        if (!(other instanceof PartCommand otherPartCommand)) {
             return false;
         }
 
-        PartCommand otherPartCommand = (PartCommand) other;
         return targetIndex.equals(otherPartCommand.targetIndex)
+                && date.equals(otherPartCommand.date)
+                && classSpaceName.equals(otherPartCommand.classSpaceName)
                 && participation.equals(otherPartCommand.participation);
     }
 
@@ -81,6 +140,8 @@ public class PartCommand extends Command {
     public String toString() {
         return new ToStringBuilder(this)
                 .add("targetIndex", targetIndex)
+                .add("date", date)
+                .add("classSpaceName", classSpaceName)
                 .add("participation", participation)
                 .toString();
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,5 +15,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_INDEXES = new Prefix("i/");
     public static final Prefix PREFIX_DATE = new Prefix("d/");
     public static final Prefix PREFIX_NEW_NAME = new Prefix("new/");
+    public static final Prefix PREFIX_PARTICIPATION = new Prefix("pv/");
 
 }

--- a/src/main/java/seedu/address/logic/parser/PartCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PartCommandParser.java
@@ -1,10 +1,19 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_GROUP;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEXES;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PARTICIPATION;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.PartCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.classspace.ClassSpaceName;
 import seedu.address.model.person.Participation;
 
 /**
@@ -18,19 +27,40 @@ public class PartCommandParser implements Parser<PartCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public PartCommand parse(String args) throws ParseException {
-        String trimmedArgs = args.trim();
-        String[] parts = trimmedArgs.split("\\s+");
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_INDEXES, PREFIX_DATE, PREFIX_GROUP, PREFIX_PARTICIPATION);
 
-        if (parts.length != 2) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_INDEXES, PREFIX_DATE, PREFIX_PARTICIPATION)
+                || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PartCommand.MESSAGE_USAGE));
         }
 
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_INDEXES, PREFIX_DATE, PREFIX_GROUP, PREFIX_PARTICIPATION);
+
         try {
-            Index index = ParserUtil.parseIndex(parts[0]);
-            Participation participation = new Participation(parts[1]);
-            return new PartCommand(index, participation);
+            Index index = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_INDEXES).get());
+            LocalDate date = ParserUtil.parseSessionDate(argMultimap.getValue(PREFIX_DATE).get());
+
+            Optional<ClassSpaceName> classSpaceName = Optional.empty();
+            if (argMultimap.getValue(PREFIX_GROUP).isPresent()) {
+                classSpaceName = Optional.of(
+                        ParserUtil.parseClassSpaceName(argMultimap.getValue(PREFIX_GROUP).get())
+                );
+            }
+
+            Participation participation =
+                    new Participation(argMultimap.getValue(PREFIX_PARTICIPATION).get());
+
+            return new PartCommand(index, date, classSpaceName, participation);
         } catch (IllegalArgumentException | ParseException e) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PartCommand.MESSAGE_USAGE), e);
         }
+    }
+
+    /**
+     * Returns true if all the specified prefixes are present in the argument multimap.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }


### PR DESCRIPTION
Current participation command does not record participation for sessions.

Recording participation for each session allows us to track the progress of students more accurately for each tutorial group.

Let's update the participation command to take in the date and the class space as parameters.

If class space is not given as a parameter it uses the current active class space.

Fixes #78 