### PR TITLE
Change Name Parameters to Include Special Characters and Reject Dangerous Inputs

### DIFF
--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names cannot be blank. Characters like ; and <> are invalid.";
+            "Names cannot be blank. Characters like semicolons and <> are invalid.";
 
     /*
      * The first character of the name must start with a Unicode letter and


### PR DESCRIPTION
The name parameter does not accept special characters for names of foreign languages.

Accepting these special characters makes it easier to add the contacts of foreign students to the address book.

Let's,
* update the name parameters to include names like Anne-Marie, Rajesh s/o Ram, José Ødegård, O'Connor, नामदेव
* update the name parameters to reject characters like <> and ; which are dangerous inputs

Fixes #233 