### PR TITLE
Remove deletesession confirmation feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteSessionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteSessionCommand.java
@@ -29,9 +29,6 @@ public class DeleteSessionCommand extends Command {
 
     public static final String MESSAGE_SUCCESS =
             "Deleted session %1$s from group %2$s and removed its attendance and participation records.";
-    public static final String MESSAGE_CONFIRMATION =
-            "This will delete session %1$s from group %2$s for every student. Run the same command with "
-                    + "\"confirm\" to proceed.";
     public static final String MESSAGE_GROUP_NOT_FOUND = "This group does not exist.";
     public static final String MESSAGE_NO_ACTIVE_GROUP =
             "No group selected. Enter a group first or provide g/GROUP_NAME.";
@@ -40,25 +37,23 @@ public class DeleteSessionCommand extends Command {
 
     private final LocalDate sessionDate;
     private final Optional<GroupName> groupName;
-    private final boolean confirmed;
 
     public DeleteSessionCommand(LocalDate sessionDate) {
-        this(sessionDate, Optional.empty(), false);
+        this(sessionDate, Optional.empty());
     }
 
     public DeleteSessionCommand(LocalDate sessionDate, GroupName groupName) {
-        this(sessionDate, Optional.of(groupName), false);
+        this(sessionDate, Optional.of(groupName));
     }
 
     /**
-     * Creates a delete-session command with optional group and confirmation state.
+     * Creates a delete-session command with an optional group.
      */
-    public DeleteSessionCommand(LocalDate sessionDate, Optional<GroupName> groupName, boolean confirmed) {
+    public DeleteSessionCommand(LocalDate sessionDate, Optional<GroupName> groupName) {
         requireNonNull(sessionDate);
         requireNonNull(groupName);
         this.sessionDate = sessionDate;
         this.groupName = groupName;
-        this.confirmed = confirmed;
     }
 
     @Override
@@ -77,10 +72,6 @@ public class DeleteSessionCommand extends Command {
                 .orElseThrow(() -> new CommandException(MESSAGE_NO_ACTIVE_GROUP));
         Group group = model.findGroupByName(targetGroup)
                 .orElseThrow(() -> new CommandException(MESSAGE_GROUP_NOT_FOUND));
-
-        if (!confirmed) {
-            return new CommandResult(String.format(MESSAGE_CONFIRMATION, sessionDate, targetGroup));
-        }
 
         Group updatedGroup = group.withoutSession(sessionDate);
         boolean sessionRemovedFromGroup = !updatedGroup.equals(group);

--- a/src/main/java/seedu/address/logic/parser/DeleteSessionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteSessionCommandParser.java
@@ -21,19 +21,17 @@ public class DeleteSessionCommandParser implements Parser<DeleteSessionCommand> 
     public DeleteSessionCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DATE, PREFIX_GROUP);
         String preamble = argMultimap.getPreamble().trim();
-        if (!arePrefixesPresent(argMultimap, PREFIX_DATE)
-                || !(preamble.isEmpty() || preamble.equalsIgnoreCase("confirm"))) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_DATE) || !preamble.isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteSessionCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_DATE, PREFIX_GROUP);
         LocalDate sessionDate = ParserUtil.parseSessionDate(argMultimap.getValue(PREFIX_DATE).get());
-        boolean confirmed = preamble.equalsIgnoreCase("confirm");
         if (argMultimap.getValue(PREFIX_GROUP).isPresent()) {
             GroupName groupName = ParserUtil.parseGroupName(argMultimap.getValue(PREFIX_GROUP).get());
-            return new DeleteSessionCommand(sessionDate, Optional.of(groupName), confirmed);
+            return new DeleteSessionCommand(sessionDate, Optional.of(groupName));
         }
-        return new DeleteSessionCommand(sessionDate, Optional.empty(), confirmed);
+        return new DeleteSessionCommand(sessionDate, Optional.empty());
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {

--- a/src/test/java/seedu/address/logic/commands/DeleteSessionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteSessionCommandTest.java
@@ -40,7 +40,7 @@ public class DeleteSessionCommandTest {
         var person = expectedModel.findPersonByMatricNumber(new MatricNumber("A1234567X")).orElseThrow();
         expectedModel.setPerson(person, person.withoutSession(T01, SESSION_DATE));
 
-        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty(), true);
+        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty());
         assertCommandSuccess(command, model,
                 String.format(DeleteSessionCommand.MESSAGE_SUCCESS, SESSION_DATE, T01), expectedModel);
 
@@ -73,7 +73,7 @@ public class DeleteSessionCommandTest {
         expectedModel.clearActiveSessionDate();
         expectedModel.updateFilteredPersonList(seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS);
 
-        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty(), true);
+        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty());
         assertCommandSuccess(command, model,
                 String.format(DeleteSessionCommand.MESSAGE_SUCCESS, SESSION_DATE, T01), expectedModel);
         assertTrue(model.getActiveSessionDate().isEmpty());
@@ -85,7 +85,7 @@ public class DeleteSessionCommandTest {
         model.addGroup(new Group(T01));
         model.switchToGroupView(T01);
 
-        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty(), true);
+        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty());
         String expectedMessage = String.format(DeleteSessionCommand.MESSAGE_SESSION_NOT_FOUND, SESSION_DATE, T01);
         assertThrows(CommandException.class, expectedMessage, () -> command.execute(model));
     }
@@ -135,7 +135,7 @@ public class DeleteSessionCommandTest {
         Group originalGroup = expectedModel.findGroupByName(T01).orElseThrow();
         expectedModel.setGroup(originalGroup, originalGroup.withoutSession(SESSION_DATE));
 
-        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty(), true);
+        DeleteSessionCommand command = new DeleteSessionCommand(SESSION_DATE, Optional.empty());
         assertCommandSuccess(command, model,
                 String.format(DeleteSessionCommand.MESSAGE_SUCCESS, SESSION_DATE, T01), expectedModel);
     }

--- a/src/test/java/seedu/address/logic/parser/DeleteSessionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteSessionCommandParserTest.java
@@ -27,4 +27,11 @@ public class DeleteSessionCommandParserTest {
                 String.format(seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                         DeleteSessionCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_confirmPreamble_throwsParseException() {
+        assertParseFailure(parser, " confirm d/2026-03-16",
+                String.format(seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                        DeleteSessionCommand.MESSAGE_USAGE));
+    }
 }


### PR DESCRIPTION
Closes #322 #321 

Standardise with other delete commands that do not have a confirmation feature (e.g deletegroup, deleteassignment, delete(contact))